### PR TITLE
Fix layout bug

### DIFF
--- a/css/airspace.css
+++ b/css/airspace.css
@@ -522,6 +522,7 @@ font header .navbar-default .navbar-nav li a:hover {
   position: absolute;
   top: 50%;
   left: 10%;
+  right: 10%;
   -webkit-transform: translate(0%, 50%);
   -moz-transform: translate(0%, 50%);
   -ms-transform: translate(0%, 50%);


### PR DESCRIPTION
Hi @ndrewtl !
This jekyll theme is very nice!

In work page,
If the explain of item is long, it become right-aligned. 

<img width="381" alt="2019-03-07 17 21 00" src="https://user-images.githubusercontent.com/16382693/53942326-d5d63680-40fd-11e9-9921-009f609d3936.png">

So, I fixed that If the explain of item is long, there is center-aligned. 

Please review!